### PR TITLE
Fix: Resolve next/font conflict by removing custom Babel configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  presets: [
-    '@babel/preset-env',
-    ['@babel/preset-react', { runtime: 'automatic' }],
-    '@babel/preset-typescript',
-  ],
-};


### PR DESCRIPTION
Removes babel.config.js to allow Next.js to use the default SWC compiler. This resolves the conflict with next/font, which requires SWC when Babel is not explicitly configured for it.

The custom babel.config.js contained standard presets (@babel/preset-env, @babel/preset-react, @babel/preset-typescript) that are handled by SWC in a Next.js environment, making the custom configuration unnecessary.